### PR TITLE
Adding 4.07.1+flambda Results (with Stdlib_Seq)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-DEPS = sequence gen core_kernel base benchmark containers
+DEPS = sequence gen core_kernel base batteries benchmark containers
 
 OPTS = -O3 -unbox-closures -unbox-closures-factor 20
 

--- a/bench.ml
+++ b/bench.ml
@@ -1,4 +1,3 @@
-
 module G = struct
   type 'a t = unit -> 'a option
 
@@ -30,8 +29,8 @@ module G = struct
       | Stop -> None
       | Cur g' ->
         match g'() with
-          | None -> next_gen(); aux ()
-          | Some _ as res -> res
+        | None -> next_gen(); aux ()
+        | Some _ as res -> res
     and next_gen() = match g() with
       | None -> state := Stop
       | Some x -> state := Cur (f x)
@@ -77,8 +76,8 @@ module G_exn = struct
       | Stop -> raise End
       | Cur g' ->
         match g'() with
-          | x -> x
-          | exception End -> next_gen(); aux ()
+        | x -> x
+        | exception End -> next_gen(); aux ()
     and next_gen() = match g() with
       | x -> state := Cur (f x)
       | exception e -> state := Stop; raise e
@@ -93,7 +92,7 @@ end
 module CPS = struct
   type (+'a, 'state) unfold = {
     unfold: 'r.
-      'state ->
+              'state ->
       on_done:(unit -> 'r) ->
       on_skip:('state -> 'r) ->
       on_yield:('state -> 'a -> 'r) ->
@@ -105,18 +104,18 @@ module CPS = struct
   let empty = CPS ((), {unfold=(fun () ~on_done ~on_skip:_ ~on_yield:_ -> on_done ())})
 
   let return x = CPS ((), {
-    unfold=(fun () ~on_done:_ ~on_skip:_ ~on_yield -> on_yield () x)
-  })
+      unfold=(fun () ~on_done:_ ~on_skip:_ ~on_yield -> on_yield () x)
+    })
 
   let map f (CPS (st, u)) = CPS (st, {
-    unfold=(fun st ~on_done ~on_skip ~on_yield ->
-      u.unfold
-        st
-        ~on_done
-        ~on_skip
-        ~on_yield:(fun st x -> on_yield st (f x))
-    );
-  })
+      unfold=(fun st ~on_done ~on_skip ~on_yield ->
+          u.unfold
+            st
+            ~on_done
+            ~on_skip
+            ~on_yield:(fun st x -> on_yield st (f x))
+        );
+    })
 
   let fold f acc (CPS (st,u)) =
     let rec loop st acc =
@@ -131,49 +130,49 @@ module CPS = struct
   let to_list_rev iter = fold (fun acc x -> x::acc) [] iter
 
   let of_list l = CPS (l, {
-    unfold=(fun l ~on_done ~on_skip:_ ~on_yield -> match l with
-      | [] -> on_done ()
-      | x :: tail -> on_yield tail x
-    );
-  })
+      unfold=(fun l ~on_done ~on_skip:_ ~on_yield -> match l with
+          | [] -> on_done ()
+          | x :: tail -> on_yield tail x
+        );
+    })
 
   let (--) i j = CPS (i, {
-    unfold=(fun i ~on_done ~on_skip:_ ~on_yield ->
-      if i>j then on_done ()
-      else on_yield (i+1) i
-    );
-  })
+      unfold=(fun i ~on_done ~on_skip:_ ~on_yield ->
+          if i>j then on_done ()
+          else on_yield (i+1) i
+        );
+    })
 
   let filter f (CPS (st, u1)) =
     CPS (st, {
-      unfold=(fun st ~on_done ~on_skip ~on_yield ->
-        u1.unfold st ~on_done ~on_skip
-          ~on_yield:(fun st' x ->
-            if f x then on_yield st' x
-            else on_skip st'
-          )
-      );
-    })
+        unfold=(fun st ~on_done ~on_skip ~on_yield ->
+            u1.unfold st ~on_done ~on_skip
+              ~on_yield:(fun st' x ->
+                  if f x then on_yield st' x
+                  else on_skip st'
+                )
+          );
+      })
 
   let flat_map : type a b. (a -> b t) -> a t -> b t
-  = fun f (CPS (st1, u1)) ->
-    (* obtain next element of u1 *)
-    let u = {
-      unfold=(fun (st1, CPS (sub_st2, sub2))
-          ~on_done ~on_skip ~on_yield ->
-        let done_ () =
-          u1.unfold st1
-            ~on_done
-            ~on_skip:(fun st1' -> on_skip (st1', empty))
-            ~on_yield:(fun st1' x1 -> on_skip (st1', f x1))
-        in
-        let skip sub_st2 = on_skip (st1, CPS (sub_st2, sub2)) in
-        let yield_ sub_st2 x2 = on_yield (st1, CPS (sub_st2,sub2)) x2 in
-        sub2.unfold sub_st2 ~on_done:done_ ~on_skip:skip ~on_yield:yield_
-      );
-    }
-    in
-    CPS ((st1, empty), u)
+    = fun f (CPS (st1, u1)) ->
+      (* obtain next element of u1 *)
+      let u = {
+        unfold=(fun (st1, CPS (sub_st2, sub2))
+                 ~on_done ~on_skip ~on_yield ->
+                 let done_ () =
+                   u1.unfold st1
+                     ~on_done
+                     ~on_skip:(fun st1' -> on_skip (st1', empty))
+                     ~on_yield:(fun st1' x1 -> on_skip (st1', f x1))
+                 in
+                 let skip sub_st2 = on_skip (st1, CPS (sub_st2, sub2)) in
+                 let yield_ sub_st2 x2 = on_yield (st1, CPS (sub_st2,sub2)) x2 in
+                 sub2.unfold sub_st2 ~on_done:done_ ~on_skip:skip ~on_yield:yield_
+               );
+      }
+      in
+      CPS ((st1, empty), u)
 end
 
 module CPS2 = struct
@@ -198,12 +197,12 @@ module CPS2 = struct
   let map f (CPS { state = st; unfold = u }) =
     CPS { state = st;
           unfold=(fun st ~on_done ~on_skip ~on_yield ->
-            u
-              st
-              ~on_done
-              ~on_skip
-              ~on_yield:(fun st x -> on_yield st (f x))
-          );
+              u
+                st
+                ~on_done
+                ~on_skip
+                ~on_yield:(fun st x -> on_yield st (f x))
+            );
         }
 
   let fold f acc (CPS { state = st; unfold = u }) =
@@ -220,27 +219,27 @@ module CPS2 = struct
 
   let of_list l = CPS { state = l;
                         unfold=(fun l ~on_done ~on_skip:_ ~on_yield -> match l with
-                          | [] -> on_done ()
-                          | x :: tail -> on_yield tail x
-                        );
+                            | [] -> on_done ()
+                            | x :: tail -> on_yield tail x
+                          );
                       }
 
   let (--) i j = CPS { state = i;
                        unfold=(fun i ~on_done ~on_skip:_ ~on_yield ->
-                         if i>j then on_done ()
-                         else on_yield (i+1) i
-                       );
+                           if i>j then on_done ()
+                           else on_yield (i+1) i
+                         );
                      }
 
   let filter f (CPS { state = st; unfold = u1 }) =
     CPS { state = st;
           unfold=(fun st ~on_done ~on_skip ~on_yield ->
-            u1 st ~on_done ~on_skip
-              ~on_yield:(fun st' x ->
-                if f x then on_yield st' x
-                else on_skip st'
-              )
-          );
+              u1 st ~on_done ~on_skip
+                ~on_yield:(fun st' x ->
+                    if f x then on_yield st' x
+                    else on_skip st'
+                  )
+            );
         }
 
   let flat_map : type a b. (a -> b t) -> a t -> b t
@@ -288,8 +287,8 @@ module Fold = struct
       fold1 s1
         ~init
         ~f:(fun acc x1 ->
-          let (Fold{fold=fold2;s=s2}) = m x1 in
-          fold2 s2 ~init:acc ~f)
+            let (Fold{fold=fold2;s=s2}) = m x1 in
+            fold2 s2 ~init:acc ~f)
     in
     Fold {fold; s=s1}
 
@@ -313,9 +312,9 @@ module LList = struct
 
   let rec map f l =
     lazy (match l with
-      | lazy Nil -> Nil
-      | lazy (Cons (x,tail)) -> Cons (f x, map f tail)
-    )
+        | lazy Nil -> Nil
+        | lazy (Cons (x,tail)) -> Cons (f x, map f tail)
+      )
 
   let filter f l =
     let rec aux f l = match l with
@@ -328,17 +327,17 @@ module LList = struct
   let rec append a b =
     lazy (
       match a with
-        | lazy Nil -> Lazy.force b
-        | lazy (Cons (x,tl)) -> Cons (x, append tl b)
+      | lazy Nil -> Lazy.force b
+      | lazy (Cons (x,tl)) -> Cons (x, append tl b)
     )
 
   let rec flat_map f l =
     lazy (
       match l with
-        | lazy Nil -> Nil
-        | lazy (Cons (x,tl)) ->
-          let res = append (f x) (flat_map f tl) in
-          Lazy.force res
+      | lazy Nil -> Nil
+      | lazy (Cons (x,tl)) ->
+        let res = append (f x) (flat_map f tl) in
+        Lazy.force res
     )
 
   let rec fold f acc = function
@@ -356,8 +355,8 @@ module UList = struct
 
   let rec map f l () =
     match l () with
-      | Nil -> Nil
-      | Cons (x,tail) -> Cons (f x, map f tail)
+    | Nil -> Nil
+    | Cons (x,tail) -> Cons (f x, map f tail)
 
   let filter f l =
     let rec aux f l () = match l () with
@@ -369,15 +368,15 @@ module UList = struct
 
   let rec append a b () =
     match a () with
-      | Nil -> b ()
-      | Cons (x,tl) -> Cons (x, append tl b)
+    | Nil -> b ()
+    | Cons (x,tl) -> Cons (x, append tl b)
 
   let rec flat_map f l () =
     match l() with
-      | Nil -> Nil
-      | Cons (x,tl) ->
-        let res = append (f x) (flat_map f tl) in
-        res ()
+    | Nil -> Nil
+    | Cons (x,tl) ->
+      let res = append (f x) (flat_map f tl) in
+      res ()
 
   let rec fold f acc l = match l() with
     | Nil -> acc
@@ -409,24 +408,24 @@ module UnCons = struct
     T {state; next=next'}
 
   type ('a, 'b, 'top_st) flat_map_state =
-    FMS :
-      { top: 'top_st;
-        sub: 'sub_st;
-        sub_next: 'sub_st -> ('b * 'sub_st) option
-      } -> ('a, 'b, 'top_st) flat_map_state
+      FMS :
+        { top: 'top_st;
+          sub: 'sub_st;
+          sub_next: 'sub_st -> ('b * 'sub_st) option
+        } -> ('a, 'b, 'top_st) flat_map_state
 
   let flat_map f (T {state; next}) =
     let rec next' (FMS { top; sub; sub_next}) =
       match sub_next sub with
-        | None ->
-          begin match next top with
-            | None -> None
-            | Some (x, top') ->
-              let T{next=sub_next; state=sub} = f x in
-              next' (FMS { top=top'; sub; sub_next; })
-          end
-        | Some (x, sub') ->
-          Some (x, FMS {top; sub=sub'; sub_next})
+      | None ->
+        begin match next top with
+          | None -> None
+          | Some (x, top') ->
+            let T{next=sub_next; state=sub} = f x in
+            next' (FMS { top=top'; sub; sub_next; })
+        end
+      | Some (x, sub') ->
+        Some (x, FMS {top; sub=sub'; sub_next})
     in
     T {
       state=FMS {top=state; sub=(); sub_next=(fun _ -> None) };
@@ -480,8 +479,8 @@ module Co = struct
 
   let[@inline] map (f: 'a -> 'b) (x:'a t) : 'b t =
     function
-      | K_map r -> K_map {r with f=(fun x -> f (r.f x))} (* compose *)
-      | k -> K_map {f;from=x K_nil;k}
+    | K_map r -> K_map {r with f=(fun x -> f (r.f x))} (* compose *)
+    | k -> K_map {f;from=x K_nil;k}
 
   let[@inline] filter (f:'a -> bool) (x:'a t) : 'a t =
     flat_map (fun x -> if f x then return x else nil) x
@@ -521,11 +520,62 @@ module Co = struct
   let fold f acc (l:_ t) =
     let rec aux f acc (k:_ kont) =
       match next_k k with
-        | _, None -> acc
-        | k', Some x -> aux f (f acc x) k'
+      | _, None -> acc
+      | k', Some x -> aux f (f acc x) k'
     in
     aux f acc (l K_nil)
 end
+
+(* the "Stdlib_Seq" library *)
+let f_std_seq () =
+  let open Seq in 
+
+  let init n f =
+    let rec aux i () =
+      if i = n then
+        Nil
+      else
+        Cons(f i, aux (i + 1))
+    in
+    if n < 0 then
+      invalid_arg "Stdlib_Seq.init"
+    else
+      aux 0
+
+  in
+  
+  let ( -- ) a b =
+    if b < a then
+      empty
+    else
+      init (b - a + 1) (fun x -> a + x)
+
+  in
+  1 -- 100_000
+  |> map (fun x -> x+1)
+  |> filter (fun x -> x mod 2 = 0)
+  |> flat_map (fun x -> x -- (x+30))
+  |> fold_left (+) 0
+
+(* the "BatSeq" library *)
+let f_batseq () =
+  let open BatSeq in
+  let rec flat_map f seq () = match seq () with
+    | Nil -> Nil
+    | Cons (x, next) ->
+      flat_map_app f (f x) next ()
+
+  (* this is [append seq (flat_map f tail)] *)
+  and flat_map_app f seq tail () = match seq () with
+    | Nil -> flat_map f tail ()
+    | Cons (x, next) ->
+      Cons (x, flat_map_app f next tail)
+  in 
+  1 -- 100_000
+  |> map (fun x -> x+1)
+  |> filter (fun x -> x mod 2 = 0)
+  |> flat_map (fun x -> x -- (x+30))
+  |> fold_left (+) 0
 
 (* the "gen" library *)
 let f_gen () =
@@ -661,28 +711,31 @@ let () =
   assert (f_fold () = f_gen());
   assert (f_uncons () = f_gen());
   assert (f_co () = f_gen());
+  assert (f_std_seq () = f_gen());
   ()
 
 let () =
   let res =
     (Sys.opaque_identity Benchmark.throughputN) ~repeat:2 3
-    [ "gen", Sys.opaque_identity f_gen, ()
-    ; "gen_no_optim", Sys.opaque_identity f_gen_noptim, ()
-    ; "g", Sys.opaque_identity f_g, ()
-    ; "g_exn", Sys.opaque_identity f_g_exn, ()
-    ; "core.sequence", Sys.opaque_identity f_core, ()
-    ; "base.sequence", Sys.opaque_identity f_base, ()
-    ; "cps", Sys.opaque_identity f_cps, ()
-    ; "cps2", Sys.opaque_identity f_cps2, ()
-    ; "fold", Sys.opaque_identity f_fold, ()
-    ; "sequence", Sys.opaque_identity f_seq, ()
-    ; "list", Sys.opaque_identity f_list, ()
-    ; "lazy_list", Sys.opaque_identity f_llist, ()
-    ; "ulist", Sys.opaque_identity f_ulist, ()
-    ; "uncons", Sys.opaque_identity f_uncons, ()
-    ; "coroutine", Sys.opaque_identity f_co, ()
-    ]
+      [ "gen", Sys.opaque_identity f_gen, ()
+      ; "gen_no_optim", Sys.opaque_identity f_gen_noptim, ()
+      ; "g", Sys.opaque_identity f_g, ()
+      ; "g_exn", Sys.opaque_identity f_g_exn, ()
+      ; "core.sequence", Sys.opaque_identity f_core, ()
+      ; "base.sequence", Sys.opaque_identity f_base, ()
+      ; "cps", Sys.opaque_identity f_cps, ()
+      ; "cps2", Sys.opaque_identity f_cps2, ()
+      ; "fold", Sys.opaque_identity f_fold, ()
+      ; "sequence", Sys.opaque_identity f_seq, ()
+      ; "list", Sys.opaque_identity f_list, ()
+      ; "lazy_list", Sys.opaque_identity f_llist, ()
+      ; "ulist", Sys.opaque_identity f_ulist, ()
+      ; "uncons", Sys.opaque_identity f_uncons, ()
+      ; "coroutine", Sys.opaque_identity f_co, ()
+      ; "batseq", Sys.opaque_identity f_batseq, ()
+      ; "std_seq", Sys.opaque_identity f_std_seq, ()
+      ]
   in
   Benchmark.tabulate res
 
-(* ocamlfind opt -O3 -unbox-closures -unbox-closures-factor 20 -package sequence -package gen -package core_kernel -package base -package benchmark -package containers -linkpkg bench.ml -o bench.native *)
+(* ocamlfind opt -O3 -unbox-closures -unbox-closures-factor 20 -package sequence -package gen -package core_kernel -package base -package batteries -package benchmark -package containers -linkpkg bench.ml -o bench.native *)

--- a/res_4.07.1_flambda.txt
+++ b/res_4.07.1_flambda.txt
@@ -1,0 +1,59 @@
+$ make run
+
+ocamlfind opt -O3 -unbox-closures -unbox-closures-factor 20 -package sequence -package gen -package core_kernel -package base -package batteries -package benchmark -package containers -linkpkg bench.ml -o bench.native
+./bench.native
+Throughputs for "gen", "gen_no_optim", "g", "g_exn", "core.sequence", "base.sequence", "cps", "cps2", "fold", "sequence", "list", "lazy_list", "ulist", "uncons", "coroutine", "batseq", "std_seq" each running 2 times for at least 3 CPU seconds:
+
+          gen:  3.41 WALL ( 3.41 usr +  0.00 sys =  3.41 CPU) @ 44.55/s (n=152)
+                3.37 WALL ( 3.37 usr +  0.00 sys =  3.37 CPU) @ 45.08/s (n=152)
+ gen_no_optim:  3.59 WALL ( 3.59 usr +  0.00 sys =  3.59 CPU) @ 40.37/s (n=145)
+                3.68 WALL ( 3.68 usr +  0.00 sys =  3.68 CPU) @ 39.43/s (n=145)
+            g:  3.12 WALL ( 3.12 usr +  0.00 sys =  3.12 CPU) @ 89.72/s (n=280)
+                3.07 WALL ( 3.07 usr +  0.00 sys =  3.07 CPU) @ 91.07/s (n=280)
+        g_exn:  3.17 WALL ( 3.15 usr +  0.00 sys =  3.15 CPU) @ 38.37/s (n=121)
+                3.13 WALL ( 3.12 usr +  0.00 sys =  3.12 CPU) @ 38.74/s (n=121)
+core.sequence:  3.23 WALL ( 3.22 usr +  0.00 sys =  3.22 CPU) @ 55.20/s (n=178)
+                3.29 WALL ( 3.24 usr +  0.02 sys =  3.26 CPU) @ 54.65/s (n=178)
+base.sequence:  3.14 WALL ( 3.09 usr +  0.01 sys =  3.10 CPU) @ 55.49/s (n=172)
+                3.00 WALL ( 3.00 usr +  0.00 sys =  3.00 CPU) @ 57.29/s (n=172)
+          cps:  3.64 WALL ( 3.62 usr +  0.00 sys =  3.63 CPU) @ 20.95/s (n=76)
+                3.63 WALL ( 3.62 usr +  0.00 sys =  3.62 CPU) @ 20.99/s (n=76)
+         cps2:  3.53 WALL ( 3.53 usr +  0.00 sys =  3.53 CPU) @ 20.70/s (n=73)
+                3.50 WALL ( 3.50 usr +  0.00 sys =  3.50 CPU) @ 20.85/s (n=73)
+         fold:  3.14 WALL ( 3.14 usr +  0.00 sys =  3.14 CPU) @ 151.52/s (n=476)
+                3.13 WALL ( 3.13 usr +  0.00 sys =  3.13 CPU) @ 151.90/s (n=476)
+     sequence:  3.25 WALL ( 3.25 usr +  0.00 sys =  3.25 CPU) @ 251.70/s (n=819)
+                3.32 WALL ( 3.32 usr +  0.00 sys =  3.32 CPU) @ 246.74/s (n=819)
+         list:  3.19 WALL ( 3.15 usr +  0.04 sys =  3.19 CPU) @  5.01/s (n=16)
+                3.12 WALL ( 3.09 usr +  0.03 sys =  3.12 CPU) @  5.13/s (n=16)
+    lazy_list:  3.04 WALL ( 3.04 usr +  0.00 sys =  3.04 CPU) @  5.59/s (n=17)
+                3.02 WALL ( 3.02 usr +  0.00 sys =  3.02 CPU) @  5.63/s (n=17)
+        ulist:  3.14 WALL ( 3.14 usr +  0.00 sys =  3.14 CPU) @ 50.98/s (n=160)
+                3.14 WALL ( 3.14 usr +  0.00 sys =  3.14 CPU) @ 50.87/s (n=160)
+       uncons:  3.15 WALL ( 3.15 usr +  0.00 sys =  3.15 CPU) @ 52.00/s (n=164)
+                3.12 WALL ( 3.12 usr +  0.00 sys =  3.12 CPU) @ 52.60/s (n=164)
+    coroutine:  3.07 WALL ( 3.07 usr +  0.00 sys =  3.07 CPU) @ 49.57/s (n=152)
+                3.09 WALL ( 3.08 usr +  0.00 sys =  3.08 CPU) @ 49.29/s (n=152)
+       batseq:  3.14 WALL ( 3.13 usr +  0.00 sys =  3.13 CPU) @ 39.60/s (n=124)
+                3.12 WALL ( 3.12 usr +  0.00 sys =  3.12 CPU) @ 39.71/s (n=124)
+      std_seq:  3.15 WALL ( 3.15 usr +  0.00 sys =  3.15 CPU) @ 42.25/s (n=133)
+                3.15 WALL ( 3.15 usr +  0.00 sys =  3.15 CPU) @ 42.26/s (n=133)
+		
+                Rate        list lazy_list  cps2   cps g_exn batseq gen_no_optim std_seq  gen coroutine ulist uncons core.sequence base.sequence    g fold sequence
+         list 5.07+-0.06/s    --      -10%  -76%  -76%  -87%   -87%         -87%    -88% -89%      -90%  -90%   -90%          -91%          -91% -94% -97%     -98%
+    lazy_list 5.61+-0.02/s   11%        --  -73%  -73%  -85%   -86%         -86%    -87% -87%      -89%  -89%   -89%          -90%          -90% -94% -96%     -98%
+         cps2 20.8+- 0.1/s  310%      270%    -- [-1%]  -46%   -48%         -48%    -51% -54%      -58%  -59%   -60%          -62%          -63% -77% -86%     -92%
+          cps 21.0+- 0.0/s  314%      274%  [1%]    --  -46%   -47%         -47%    -50% -53%      -58%  -59%   -60%          -62%          -63% -77% -86%     -92%
+        g_exn 38.6+- 0.2/s  661%      587%   86%   84%    --    -3%        [-3%]     -9% -14%      -22%  -24%   -26%          -30%          -32% -57% -75%     -85%
+       batseq 39.7+- 0.1/s  683%      607%   91%   89%    3%     --        [-1%]     -6% -12%      -20%  -22%   -24%          -28%          -30% -56% -74%     -84%
+ gen_no_optim 39.9+- 0.4/s  687%      611%   92%   90%  [3%]   [1%]           --     -6% -11%      -19%  -22%   -24%          -27%          -29% -56% -74%     -84%
+      std_seq 42.3+- 0.0/s  734%      653%  103%  101%   10%     7%           6%      --  -6%      -15%  -17%   -19%          -23%          -25% -53% -72%     -83%
+          gen 44.8+- 0.2/s  784%      699%  116%  114%   16%    13%          12%      6%   --       -9%  -12%   -14%          -18%          -21% -50% -70%     -82%
+    coroutine 49.4+- 0.1/s  875%      781%  138%  136%   28%    25%          24%     17%  10%        --   -3%    -5%          -10%          -12% -45% -67%     -80%
+        ulist 50.9+- 0.0/s  905%      808%  145%  143%   32%    28%          28%     21%  14%        3%    --    -3%           -7%          -10% -44% -66%     -80%
+       uncons 52.3+- 0.3/s  932%      832%  152%  149%   36%    32%          31%     24%  17%        6%    3%     --           -5%           -7% -42% -66%     -79%
+core.sequence 54.9+- 0.3/s  984%      879%  164%  162%   42%    38%          38%     30%  23%       11%    8%     5%            --         [-3%] -39% -64%     -78%
+base.sequence 56.4+- 0.9/s 1013%      905%  171%  169%   46%    42%          41%     33%  26%       14%   11%     8%          [3%]            -- -38% -63%     -77%
+            g 90.4+- 0.6/s 1684%     1512%  335%  331%  134%   128%         127%    114% 102%       83%   78%    73%           65%           60%   -- -40%     -64%
+         fold  152+-   0/s 2894%     2605%  630%  624%  294%   283%         280%    259% 239%      207%  198%   190%          176%          169%  68%   --     -39%
+     sequence  249+-   2/s 4818%     4343% 1099% 1089%  546%   528%         525%    490% 456%      404%  389%   377%          354%          342% 176%  64%       --


### PR DESCRIPTION
Always impressed by the speed performance of Sequence (at least for this kind of micro-benchmarks).

Question:
Any specific reasons for not having more functions available in Stdlib_Seq?

(e.g. Seq.init or Seq.(-) as needed here or Seq.repeat, Seq.fold_map, Seq.find, Seq.append ...)